### PR TITLE
Improve chainId error message

### DIFF
--- a/src/sender.js
+++ b/src/sender.js
@@ -31,7 +31,7 @@ async function initialize() {
       cb: main
     })
   } catch (e) {
-    console.log(e)
+    console.log(e.message)
     process.exit(1)
   }
 }

--- a/src/tx/web3.js
+++ b/src/tx/web3.js
@@ -7,8 +7,12 @@ function getBlockNumber(web3) {
   return web3.eth.getBlockNumber()
 }
 
-function getChainId(web3) {
-  return web3.eth.net.getId()
+async function getChainId(web3) {
+  try {
+    return await web3.eth.net.getId()
+  } catch (e) {
+    throw new Error(`Chain Id cannot be obtained`)
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
This PR completes the pending task of improving the error message when chain Id cannot be obtained.

I didn't include if it is `home` or `foreign` in the message because that kind of information will be provided on the attributes of the log when [extending logging functionality](https://github.com/poanetwork/bridge-nodejs/issues/8)

Closes #17 