### PR TITLE
Closes #12. Use EIP-55 addresses

### DIFF
--- a/src/events/processCollectedSignatures.js
+++ b/src/events/processCollectedSignatures.js
@@ -30,7 +30,8 @@ async function processCollectedSignatures(signatures) {
       messageHash,
       NumberOfCollectedSignatures
     } = colSignature.returnValues
-    if (authorityResponsibleForRelay === VALIDATOR_ADDRESS) {
+
+    if (authorityResponsibleForRelay === web3Home.utils.toChecksumAddress(VALIDATOR_ADDRESS)) {
       const message = await homeBridge.methods.message(messageHash).call()
 
       const requiredSignatures = []


### PR DESCRIPTION
Convert to CheckSum address VALIDATOR_ADDRESS if it was provided in lowercase or uppercase.

Ethereum should always return EIP-55 from the event