### PR TITLE
Support several RPC URLs

### DIFF
--- a/config/base.config.js
+++ b/config/base.config.js
@@ -6,6 +6,8 @@ const foreignNativeAbi = require('../abis/ForeignBridgeNativeToErc.abi')
 const homeErcAbi = require('../abis/HomeBridgeErcToErc.abi')
 const foreignErcAbi = require('../abis/ForeignBridgeErcToErc.abi')
 
+const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
+
 const isErcToErc = process.env.BRIDGE_MODE && process.env.BRIDGE_MODE === 'ERC_TO_ERC'
 
 const homeAbi = isErcToErc ? homeErcAbi : homeNativeAbi
@@ -19,8 +21,11 @@ const bridgeConfig = {
   eventFilter: {}
 }
 
+const homeRpcUrl = rpcUrlsManager.getHomeUrl()
+const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
+
 const homeConfig = {
-  url: process.env.HOME_RPC_URL,
+  url: homeRpcUrl,
   eventContractAddress: process.env.HOME_BRIDGE_ADDRESS,
   eventAbi: homeAbi,
   bridgeContractAddress: process.env.HOME_BRIDGE_ADDRESS,
@@ -30,7 +35,7 @@ const homeConfig = {
 }
 
 const foreignConfig = {
-  url: process.env.FOREIGN_RPC_URL,
+  url: foreignRpcUrl,
   eventContractAddress: process.env.FOREIGN_BRIDGE_ADDRESS,
   eventAbi: foreignAbi,
   bridgeContractAddress: process.env.FOREIGN_BRIDGE_ADDRESS,

--- a/config/base.config.js
+++ b/config/base.config.js
@@ -21,11 +21,8 @@ const bridgeConfig = {
   eventFilter: {}
 }
 
-const homeRpcUrl = rpcUrlsManager.getHomeUrl()
-const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
-
 const homeConfig = {
-  url: homeRpcUrl,
+  urls: rpcUrlsManager.homeUrls,
   eventContractAddress: process.env.HOME_BRIDGE_ADDRESS,
   eventAbi: homeAbi,
   bridgeContractAddress: process.env.HOME_BRIDGE_ADDRESS,
@@ -35,7 +32,7 @@ const homeConfig = {
 }
 
 const foreignConfig = {
-  url: foreignRpcUrl,
+  urls: rpcUrlsManager.foreignUrls,
   eventContractAddress: process.env.FOREIGN_BRIDGE_ADDRESS,
   eventAbi: foreignAbi,
   bridgeContractAddress: process.env.FOREIGN_BRIDGE_ADDRESS,

--- a/config/foreign-sender.config.js
+++ b/config/foreign-sender.config.js
@@ -1,7 +1,9 @@
 require('dotenv').config()
 
+const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
+
 module.exports = {
-  url: process.env.FOREIGN_RPC_URL,
+  url: rpcUrlsManager.getForeignUrl(),
   queue: 'foreign',
   id: 'foreign',
   name: 'sender-foreign'

--- a/config/foreign-sender.config.js
+++ b/config/foreign-sender.config.js
@@ -3,7 +3,7 @@ require('dotenv').config()
 const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
 
 module.exports = {
-  url: rpcUrlsManager.getForeignUrl(),
+  urls: rpcUrlsManager.foreignUrls,
   queue: 'foreign',
   id: 'foreign',
   name: 'sender-foreign'

--- a/config/home-sender.config.js
+++ b/config/home-sender.config.js
@@ -3,7 +3,7 @@ require('dotenv').config()
 const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
 
 module.exports = {
-  url: rpcUrlsManager.getHomeUrl(),
+  urls: rpcUrlsManager.homeUrls,
   queue: 'home',
   id: 'home',
   name: 'sender-home'

--- a/config/home-sender.config.js
+++ b/config/home-sender.config.js
@@ -1,7 +1,9 @@
 require('dotenv').config()
 
+const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
+
 module.exports = {
-  url: process.env.HOME_RPC_URL,
+  url: rpcUrlsManager.getHomeUrl(),
   queue: 'home',
   id: 'home',
   name: 'sender-home'

--- a/e2e/scripts/deployERC20.js
+++ b/e2e/scripts/deployERC20.js
@@ -29,10 +29,6 @@ async function deployErc20() {
     foreignNonce++
     console.log('[Foreign] POA20 Test: ', poa20foreign.options.address)
 
-    // TODO: Fix this when the e2e are modified to use the whole repo as docker context.
-    // Right now, we can't require the RpcUrlManager from here.
-    const foreignRpcUrl = process.env.FOREIGN_RPC_URL.split(',')[0]
-
     const mintData = await poa20foreign.methods
       .mint(user.address, '1000000000000000000')
       .encodeABI({ from: DEPLOYMENT_ACCOUNT_ADDRESS })
@@ -41,7 +37,7 @@ async function deployErc20() {
       nonce: foreignNonce,
       to: poa20foreign.options.address,
       privateKey: deploymentPrivateKey,
-      url: foreignRpcUrl
+      url: process.env.FOREIGN_RPC_URL
     })
   } catch (e) {
     console.log(e)

--- a/e2e/scripts/deployERC20.js
+++ b/e2e/scripts/deployERC20.js
@@ -10,8 +10,7 @@ const {
 } = require('../submodules/poa-bridge-contracts/deploy/src/deploymentUtils')
 const {
   web3Foreign,
-  deploymentPrivateKey,
-  FOREIGN_RPC_URL
+  deploymentPrivateKey
 } = require('../submodules/poa-bridge-contracts/deploy/src/web3')
 const POA20 = require('../submodules/poa-bridge-contracts/build/contracts/ERC677BridgeToken.json')
 const { user } = require('../constants.json')
@@ -30,6 +29,10 @@ async function deployErc20() {
     foreignNonce++
     console.log('[Foreign] POA20 Test: ', poa20foreign.options.address)
 
+    // TODO: Fix this when the e2e are modified to use the whole repo as docker context.
+    // Right now, we can't require the RpcUrlManager from here.
+    const foreignRpcUrl = process.env.FOREIGN_RPC_URL.split(',')[0]
+
     const mintData = await poa20foreign.methods
       .mint(user.address, '1000000000000000000')
       .encodeABI({ from: DEPLOYMENT_ACCOUNT_ADDRESS })
@@ -38,7 +41,7 @@ async function deployErc20() {
       nonce: foreignNonce,
       to: poa20foreign.options.address,
       privateKey: deploymentPrivateKey,
-      url: FOREIGN_RPC_URL
+      url: foreignRpcUrl
     })
   } catch (e) {
     console.log(e)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2397,8 +2397,7 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-      "dev": true
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "bignumber.js": "^7.2.1",
     "dotenv": "^5.0.1",
     "ioredis": "^3.2.2",
+    "lodash": "^4.17.10",
     "node-fetch": "^2.1.2",
     "pino": "^4.17.3",
     "promise-retry": "^1.1.1",

--- a/scripts/getValidatorStartBlocks.js
+++ b/scripts/getValidatorStartBlocks.js
@@ -46,8 +46,8 @@ async function getStartBlock(rpcUrl, bridgeAddress, bridgeAbi) {
 async function main() {
   const { HOME_BRIDGE_ADDRESS, FOREIGN_BRIDGE_ADDRESS } = process.env
 
-  const homeRpcUrl = rpcUrlsManager.getHomeUrl()
-  const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
+  const homeRpcUrl = rpcUrlsManager.homeUrls[0]
+  const foreignRpcUrl = rpcUrlsManager.foreignUrls[0]
   const homeStartBlock = await getStartBlock(homeRpcUrl, HOME_BRIDGE_ADDRESS, homeABI)
   const foreignStartBlock = await getStartBlock(foreignRpcUrl, FOREIGN_BRIDGE_ADDRESS, foreignABI)
   const result = {

--- a/scripts/getValidatorStartBlocks.js
+++ b/scripts/getValidatorStartBlocks.js
@@ -9,6 +9,8 @@ const HomeErcABI = require('../abis/HomeBridgeErcToErc.abi')
 const ForeignErcABI = require('../abis/ForeignBridgeErcToErc.abi')
 const bridgeValidatorsABI = require('../abis/BridgeValidators.abi')
 
+const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
+
 const isErcToErc = process.env.BRIDGE_MODE && process.env.BRIDGE_MODE === 'ERC_TO_ERC'
 
 const homeABI = isErcToErc ? HomeErcABI : HomeNativeABI
@@ -42,10 +44,12 @@ async function getStartBlock(rpcUrl, bridgeAddress, bridgeAbi) {
 }
 
 async function main() {
-  const { HOME_RPC_URL, FOREIGN_RPC_URL, HOME_BRIDGE_ADDRESS, FOREIGN_BRIDGE_ADDRESS } = process.env
+  const { HOME_BRIDGE_ADDRESS, FOREIGN_BRIDGE_ADDRESS } = process.env
 
-  const homeStartBlock = await getStartBlock(HOME_RPC_URL, HOME_BRIDGE_ADDRESS, homeABI)
-  const foreignStartBlock = await getStartBlock(FOREIGN_RPC_URL, FOREIGN_BRIDGE_ADDRESS, foreignABI)
+  const homeRpcUrl = rpcUrlsManager.getHomeUrl()
+  const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
+  const homeStartBlock = await getStartBlock(homeRpcUrl, HOME_BRIDGE_ADDRESS, homeABI)
+  const foreignStartBlock = await getStartBlock(foreignRpcUrl, FOREIGN_BRIDGE_ADDRESS, foreignABI)
   const result = {
     homeStartBlock,
     foreignStartBlock

--- a/scripts/sendUserTxToErcForeign.js
+++ b/scripts/sendUserTxToErcForeign.js
@@ -40,7 +40,7 @@ const ERC20_ABI = [
   }
 ]
 
-const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
+const foreignRpcUrl = rpcUrlsManager.foreignUrls[0]
 const foreignProvider = new Web3.providers.HttpProvider(foreignRpcUrl)
 const web3Foreign = new Web3(foreignProvider)
 

--- a/scripts/sendUserTxToErcForeign.js
+++ b/scripts/sendUserTxToErcForeign.js
@@ -49,12 +49,12 @@ const poa20 = new web3Foreign.eth.Contract(ERC20_ABI, ERC20_TOKEN_ADDRESS)
 async function main() {
   try {
     const foreignChaindId = await sendRawTx({
-      url: foreignRpcUrl,
+      urls: [foreignRpcUrl],
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      url: foreignRpcUrl,
+      urls: [foreignRpcUrl],
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -68,7 +68,7 @@ async function main() {
         .transfer(FOREIGN_BRIDGE_ADDRESS, Web3Utils.toWei(FOREIGN_MIN_AMOUNT_PER_TX))
         .encodeABI({ from: USER_ADDRESS })
       const txHash = await sendTx({
-        rpcUrl: foreignRpcUrl,
+        rpcUrls: [foreignRpcUrl],
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data,
         nonce,

--- a/scripts/sendUserTxToErcForeign.js
+++ b/scripts/sendUserTxToErcForeign.js
@@ -1,13 +1,13 @@
 require('dotenv').config()
 const Web3 = require('web3')
 const Web3Utils = require('web3-utils')
+const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
 const { sendTx, sendRawTx } = require('../src/tx/sendTx')
 
 const {
   USER_ADDRESS,
   USER_ADDRESS_PRIVATE_KEY,
   FOREIGN_BRIDGE_ADDRESS,
-  FOREIGN_RPC_URL,
   FOREIGN_MIN_AMOUNT_PER_TX,
   ERC20_TOKEN_ADDRESS
 } = process.env
@@ -40,7 +40,8 @@ const ERC20_ABI = [
   }
 ]
 
-const foreignProvider = new Web3.providers.HttpProvider(FOREIGN_RPC_URL)
+const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
+const foreignProvider = new Web3.providers.HttpProvider(foreignRpcUrl)
 const web3Foreign = new Web3(foreignProvider)
 
 const poa20 = new web3Foreign.eth.Contract(ERC20_ABI, ERC20_TOKEN_ADDRESS)
@@ -48,12 +49,12 @@ const poa20 = new web3Foreign.eth.Contract(ERC20_ABI, ERC20_TOKEN_ADDRESS)
 async function main() {
   try {
     const foreignChaindId = await sendRawTx({
-      url: FOREIGN_RPC_URL,
+      url: foreignRpcUrl,
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      url: FOREIGN_RPC_URL,
+      url: foreignRpcUrl,
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -67,7 +68,7 @@ async function main() {
         .transfer(FOREIGN_BRIDGE_ADDRESS, Web3Utils.toWei(FOREIGN_MIN_AMOUNT_PER_TX))
         .encodeABI({ from: USER_ADDRESS })
       const txHash = await sendTx({
-        rpcUrl: FOREIGN_RPC_URL,
+        rpcUrl: foreignRpcUrl,
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data,
         nonce,

--- a/scripts/sendUserTxToErcForeign.js
+++ b/scripts/sendUserTxToErcForeign.js
@@ -49,12 +49,12 @@ const poa20 = new web3Foreign.eth.Contract(ERC20_ABI, ERC20_TOKEN_ADDRESS)
 async function main() {
   try {
     const foreignChaindId = await sendRawTx({
-      urls: [foreignRpcUrl],
+      chain: 'foreign',
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      urls: [foreignRpcUrl],
+      chain: 'foreign',
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -68,7 +68,7 @@ async function main() {
         .transfer(FOREIGN_BRIDGE_ADDRESS, Web3Utils.toWei(FOREIGN_MIN_AMOUNT_PER_TX))
         .encodeABI({ from: USER_ADDRESS })
       const txHash = await sendTx({
-        rpcUrls: [foreignRpcUrl],
+        chain: 'foreign',
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data,
         nonce,

--- a/scripts/sendUserTxToErcHome.js
+++ b/scripts/sendUserTxToErcHome.js
@@ -1,13 +1,13 @@
 require('dotenv').config()
 const Web3 = require('web3')
 const Web3Utils = require('web3-utils')
+const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
 const { sendTx, sendRawTx } = require('../src/tx/sendTx')
 
 const {
   USER_ADDRESS,
   USER_ADDRESS_PRIVATE_KEY,
   HOME_BRIDGE_ADDRESS,
-  HOME_RPC_URL,
   HOME_MIN_AMOUNT_PER_TX,
   BRIDGEABLE_TOKEN_ADDRESS
 } = process.env
@@ -45,7 +45,8 @@ const BRIDGEABLE_TOKEN_ABI = [
   }
 ]
 
-const homeProvider = new Web3.providers.HttpProvider(HOME_RPC_URL)
+const homeRpcUrl = rpcUrlsManager.getHomeUrl()
+const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
 const web3Home = new Web3(homeProvider)
 
 const erc677 = new web3Home.eth.Contract(BRIDGEABLE_TOKEN_ABI, BRIDGEABLE_TOKEN_ADDRESS)
@@ -53,12 +54,12 @@ const erc677 = new web3Home.eth.Contract(BRIDGEABLE_TOKEN_ABI, BRIDGEABLE_TOKEN_
 async function main() {
   try {
     const homeChainId = await sendRawTx({
-      url: HOME_RPC_URL,
+      url: homeRpcUrl,
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      url: HOME_RPC_URL,
+      url: homeRpcUrl,
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -72,7 +73,7 @@ async function main() {
         .transferAndCall(HOME_BRIDGE_ADDRESS, Web3Utils.toWei(HOME_MIN_AMOUNT_PER_TX), '0x')
         .encodeABI({ from: USER_ADDRESS })
       const txHash = await sendTx({
-        rpcUrl: HOME_RPC_URL,
+        rpcUrl: homeRpcUrl,
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data,
         nonce,

--- a/scripts/sendUserTxToErcHome.js
+++ b/scripts/sendUserTxToErcHome.js
@@ -45,7 +45,7 @@ const BRIDGEABLE_TOKEN_ABI = [
   }
 ]
 
-const homeRpcUrl = rpcUrlsManager.getHomeUrl()
+const homeRpcUrl = rpcUrlsManager.homeUrls[0]
 const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
 const web3Home = new Web3(homeProvider)
 

--- a/scripts/sendUserTxToErcHome.js
+++ b/scripts/sendUserTxToErcHome.js
@@ -54,12 +54,12 @@ const erc677 = new web3Home.eth.Contract(BRIDGEABLE_TOKEN_ABI, BRIDGEABLE_TOKEN_
 async function main() {
   try {
     const homeChainId = await sendRawTx({
-      url: homeRpcUrl,
+      urls: [homeRpcUrl],
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      url: homeRpcUrl,
+      urls: [homeRpcUrl],
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -73,7 +73,7 @@ async function main() {
         .transferAndCall(HOME_BRIDGE_ADDRESS, Web3Utils.toWei(HOME_MIN_AMOUNT_PER_TX), '0x')
         .encodeABI({ from: USER_ADDRESS })
       const txHash = await sendTx({
-        rpcUrl: homeRpcUrl,
+        rpcUrls: [homeRpcUrl],
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data,
         nonce,

--- a/scripts/sendUserTxToErcHome.js
+++ b/scripts/sendUserTxToErcHome.js
@@ -54,12 +54,12 @@ const erc677 = new web3Home.eth.Contract(BRIDGEABLE_TOKEN_ABI, BRIDGEABLE_TOKEN_
 async function main() {
   try {
     const homeChainId = await sendRawTx({
-      urls: [homeRpcUrl],
+      chain: 'home',
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      urls: [homeRpcUrl],
+      chain: 'home',
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -73,7 +73,7 @@ async function main() {
         .transferAndCall(HOME_BRIDGE_ADDRESS, Web3Utils.toWei(HOME_MIN_AMOUNT_PER_TX), '0x')
         .encodeABI({ from: USER_ADDRESS })
       const txHash = await sendTx({
-        rpcUrls: [homeRpcUrl],
+        chain: 'home',
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data,
         nonce,

--- a/scripts/sendUserTxToForeign.js
+++ b/scripts/sendUserTxToForeign.js
@@ -54,12 +54,12 @@ const poa20 = new web3Foreign.eth.Contract(ERC20_ABI, ERC20_TOKEN_ADDRESS)
 async function main() {
   try {
     const foreignChaindId = await sendRawTx({
-      url: foreignRpcUrl,
+      urls: [foreignRpcUrl],
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      url: foreignRpcUrl,
+      urls: [foreignRpcUrl],
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -73,7 +73,7 @@ async function main() {
         .transferAndCall(FOREIGN_BRIDGE_ADDRESS, Web3Utils.toWei(FOREIGN_MIN_AMOUNT_PER_TX), '0x')
         .encodeABI({ from: USER_ADDRESS })
       const txHash = await sendTx({
-        rpcUrl: foreignRpcUrl,
+        rpcUrls: [foreignRpcUrl],
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data,
         nonce,

--- a/scripts/sendUserTxToForeign.js
+++ b/scripts/sendUserTxToForeign.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 const Web3 = require('web3')
 const Web3Utils = require('web3-utils')
+const HttpListProvider = require('../src/utils/HttpListProvider')
 const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
 const { sendTx, sendRawTx } = require('../src/tx/sendTx')
 
@@ -45,8 +46,7 @@ const ERC20_ABI = [
   }
 ]
 
-const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
-const foreignProvider = new Web3.providers.HttpProvider(foreignRpcUrl)
+const foreignProvider = new HttpListProvider(rpcUrlsManager.foreignUrls)
 const web3Foreign = new Web3(foreignProvider)
 
 const poa20 = new web3Foreign.eth.Contract(ERC20_ABI, ERC20_TOKEN_ADDRESS)
@@ -54,12 +54,12 @@ const poa20 = new web3Foreign.eth.Contract(ERC20_ABI, ERC20_TOKEN_ADDRESS)
 async function main() {
   try {
     const foreignChaindId = await sendRawTx({
-      urls: [foreignRpcUrl],
+      urls: rpcUrlsManager.foreignUrls,
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      urls: [foreignRpcUrl],
+      urls: rpcUrlsManager.foreignUrls,
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -73,7 +73,7 @@ async function main() {
         .transferAndCall(FOREIGN_BRIDGE_ADDRESS, Web3Utils.toWei(FOREIGN_MIN_AMOUNT_PER_TX), '0x')
         .encodeABI({ from: USER_ADDRESS })
       const txHash = await sendTx({
-        rpcUrls: [foreignRpcUrl],
+        rpcUrls: rpcUrlsManager.foreignUrls,
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data,
         nonce,

--- a/scripts/sendUserTxToForeign.js
+++ b/scripts/sendUserTxToForeign.js
@@ -54,12 +54,12 @@ const poa20 = new web3Foreign.eth.Contract(ERC20_ABI, ERC20_TOKEN_ADDRESS)
 async function main() {
   try {
     const foreignChaindId = await sendRawTx({
-      urls: rpcUrlsManager.foreignUrls,
+      chain: 'foreign',
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      urls: rpcUrlsManager.foreignUrls,
+      chain: 'foreign',
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -73,7 +73,7 @@ async function main() {
         .transferAndCall(FOREIGN_BRIDGE_ADDRESS, Web3Utils.toWei(FOREIGN_MIN_AMOUNT_PER_TX), '0x')
         .encodeABI({ from: USER_ADDRESS })
       const txHash = await sendTx({
-        rpcUrls: rpcUrlsManager.foreignUrls,
+        chain: 'foreign',
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data,
         nonce,

--- a/scripts/sendUserTxToHome.js
+++ b/scripts/sendUserTxToHome.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 const Web3 = require('web3')
 const Web3Utils = require('web3-utils')
+const HttpListProvider = require('../src/utils/HttpListProvider')
 const { sendTx, sendRawTx } = require('../src/tx/sendTx')
 const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
 
@@ -13,19 +14,18 @@ const {
 
 const NUMBER_OF_DEPOSITS_TO_SEND = process.argv[2] || 1
 
-const homeRpcUrl = rpcUrlsManager.getHomeUrl()
-const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
+const homeProvider = HttpListProvider(rpcUrlsManager.homeUrls)
 const web3Home = new Web3(homeProvider)
 
 async function main() {
   try {
     const homeChaindId = await sendRawTx({
-      urls: [homeRpcUrl],
+      urls: rpcUrlsManager.homeUrls,
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      urls: [homeRpcUrl],
+      urls: rpcUrlsManager.homeUrls,
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -33,7 +33,7 @@ async function main() {
     let actualSent = 0
     for (let i = 0; i < Number(NUMBER_OF_DEPOSITS_TO_SEND); i++) {
       const txHash = await sendTx({
-        rpcUrls: [homeRpcUrl],
+        rpcUrls: rpcUrlsManager.homeUrls,
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data: '0x',
         nonce,

--- a/scripts/sendUserTxToHome.js
+++ b/scripts/sendUserTxToHome.js
@@ -20,12 +20,12 @@ const web3Home = new Web3(homeProvider)
 async function main() {
   try {
     const homeChaindId = await sendRawTx({
-      url: homeRpcUrl,
+      urls: [homeRpcUrl],
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      url: homeRpcUrl,
+      urls: [homeRpcUrl],
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -33,7 +33,7 @@ async function main() {
     let actualSent = 0
     for (let i = 0; i < Number(NUMBER_OF_DEPOSITS_TO_SEND); i++) {
       const txHash = await sendTx({
-        rpcUrl: homeRpcUrl,
+        rpcUrls: [homeRpcUrl],
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data: '0x',
         nonce,

--- a/scripts/sendUserTxToHome.js
+++ b/scripts/sendUserTxToHome.js
@@ -20,12 +20,12 @@ const web3Home = new Web3(homeProvider)
 async function main() {
   try {
     const homeChaindId = await sendRawTx({
-      urls: rpcUrlsManager.homeUrls,
+      chain: 'home',
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      urls: rpcUrlsManager.homeUrls,
+      chain: 'home',
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -33,7 +33,7 @@ async function main() {
     let actualSent = 0
     for (let i = 0; i < Number(NUMBER_OF_DEPOSITS_TO_SEND); i++) {
       const txHash = await sendTx({
-        rpcUrls: rpcUrlsManager.homeUrls,
+        chain: 'home',
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data: '0x',
         nonce,

--- a/scripts/sendUserTxToHome.js
+++ b/scripts/sendUserTxToHome.js
@@ -2,29 +2,30 @@ require('dotenv').config()
 const Web3 = require('web3')
 const Web3Utils = require('web3-utils')
 const { sendTx, sendRawTx } = require('../src/tx/sendTx')
+const rpcUrlsManager = require('../src/services/getRpcUrlsManager')
 
 const {
   USER_ADDRESS,
   USER_ADDRESS_PRIVATE_KEY,
   HOME_BRIDGE_ADDRESS,
-  HOME_RPC_URL,
   HOME_MIN_AMOUNT_PER_TX
 } = process.env
 
 const NUMBER_OF_DEPOSITS_TO_SEND = process.argv[2] || 1
 
-const homeProvider = new Web3.providers.HttpProvider(HOME_RPC_URL)
+const homeRpcUrl = rpcUrlsManager.getHomeUrl()
+const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
 const web3Home = new Web3(homeProvider)
 
 async function main() {
   try {
     const homeChaindId = await sendRawTx({
-      url: HOME_RPC_URL,
+      url: homeRpcUrl,
       params: [],
       method: 'net_version'
     })
     let nonce = await sendRawTx({
-      url: HOME_RPC_URL,
+      url: homeRpcUrl,
       method: 'eth_getTransactionCount',
       params: [USER_ADDRESS, 'latest']
     })
@@ -32,7 +33,7 @@ async function main() {
     let actualSent = 0
     for (let i = 0; i < Number(NUMBER_OF_DEPOSITS_TO_SEND); i++) {
       const txHash = await sendTx({
-        rpcUrl: HOME_RPC_URL,
+        rpcUrl: homeRpcUrl,
         privateKey: USER_ADDRESS_PRIVATE_KEY,
         data: '0x',
         nonce,

--- a/src/events/processAffirmationRequests.js
+++ b/src/events/processAffirmationRequests.js
@@ -1,13 +1,13 @@
 require('dotenv').config()
 const Web3 = require('web3')
+const HttpListProvider = require('../utils/HttpListProvider')
 const logger = require('../services/logger')
 const rpcUrlsManager = require('../services/getRpcUrlsManager')
 
 const { VALIDATOR_ADDRESS } = process.env
 
 function processAffirmationRequestsBuilder(config) {
-  const homeRpcUrl = rpcUrlsManager.getHomeUrl()
-  const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
+  const homeProvider = new HttpListProvider(rpcUrlsManager.homeUrls)
   const web3Home = new Web3(homeProvider)
   const homeBridge = new web3Home.eth.Contract(config.homeBridgeAbi, config.homeBridgeAddress)
 

--- a/src/events/processAffirmationRequests.js
+++ b/src/events/processAffirmationRequests.js
@@ -1,11 +1,13 @@
 require('dotenv').config()
 const Web3 = require('web3')
 const logger = require('../services/logger')
+const rpcUrlsManager = require('../services/getRpcUrlsManager')
 
-const { HOME_RPC_URL, VALIDATOR_ADDRESS } = process.env
+const { VALIDATOR_ADDRESS } = process.env
 
 function processAffirmationRequestsBuilder(config) {
-  const homeProvider = new Web3.providers.HttpProvider(HOME_RPC_URL)
+  const homeRpcUrl = rpcUrlsManager.getHomeUrl()
+  const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
   const web3Home = new Web3(homeProvider)
   const homeBridge = new web3Home.eth.Contract(config.homeBridgeAbi, config.homeBridgeAddress)
 

--- a/src/events/processCollectedSignatures.js
+++ b/src/events/processCollectedSignatures.js
@@ -1,5 +1,6 @@
 require('dotenv').config()
 const Web3 = require('web3')
+const HttpListProvider = require('../utils/HttpListProvider')
 const logger = require('../services/logger')
 const rpcUrlsManager = require('../services/getRpcUrlsManager')
 const { signatureToVRS } = require('../utils/message')
@@ -7,13 +8,11 @@ const { signatureToVRS } = require('../utils/message')
 const { VALIDATOR_ADDRESS } = process.env
 
 function processCollectedSignaturesBuilder(config) {
-  const homeRpcUrl = rpcUrlsManager.getHomeUrl()
-  const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
+  const homeProvider = new HttpListProvider(rpcUrlsManager.homeUrls)
   const web3Home = new Web3(homeProvider)
   const homeBridge = new web3Home.eth.Contract(config.homeBridgeAbi, config.homeBridgeAddress)
 
-  const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
-  const foreignProvider = new Web3.providers.HttpProvider(foreignRpcUrl)
+  const foreignProvider = new HttpListProvider(rpcUrlsManager.foreignUrls)
   const web3Foreign = new Web3(foreignProvider)
   const foreignBridge = new web3Foreign.eth.Contract(
     config.foreignBridgeAbi,

--- a/src/events/processCollectedSignatures.js
+++ b/src/events/processCollectedSignatures.js
@@ -1,16 +1,19 @@
 require('dotenv').config()
 const Web3 = require('web3')
 const logger = require('../services/logger')
+const rpcUrlsManager = require('../services/getRpcUrlsManager')
 const { signatureToVRS } = require('../utils/message')
 
-const { HOME_RPC_URL, FOREIGN_RPC_URL, VALIDATOR_ADDRESS } = process.env
+const { VALIDATOR_ADDRESS } = process.env
 
 function processCollectedSignaturesBuilder(config) {
-  const homeProvider = new Web3.providers.HttpProvider(HOME_RPC_URL)
+  const homeRpcUrl = rpcUrlsManager.getHomeUrl()
+  const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
   const web3Home = new Web3(homeProvider)
   const homeBridge = new web3Home.eth.Contract(config.homeBridgeAbi, config.homeBridgeAddress)
 
-  const foreignProvider = new Web3.providers.HttpProvider(FOREIGN_RPC_URL)
+  const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
+  const foreignProvider = new Web3.providers.HttpProvider(foreignRpcUrl)
   const web3Foreign = new Web3(foreignProvider)
   const foreignBridge = new web3Foreign.eth.Contract(
     config.foreignBridgeAbi,

--- a/src/events/processSignatureRequests.js
+++ b/src/events/processSignatureRequests.js
@@ -1,5 +1,6 @@
 require('dotenv').config()
 const Web3 = require('web3')
+const HttpListProvider = require('../utils/HttpListProvider')
 const logger = require('../services/logger')
 const rpcUrlsManager = require('../services/getRpcUrlsManager')
 const { createMessage } = require('../utils/message')
@@ -7,8 +8,7 @@ const { createMessage } = require('../utils/message')
 const { VALIDATOR_ADDRESS, VALIDATOR_ADDRESS_PRIVATE_KEY } = process.env
 
 function processSignatureRequestsBuilder(config) {
-  const homeRpcUrl = rpcUrlsManager.getHomeUrl()
-  const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
+  const homeProvider = new HttpListProvider(rpcUrlsManager.homeUrls)
   const web3Home = new Web3(homeProvider)
   const homeBridge = new web3Home.eth.Contract(config.homeBridgeAbi, config.homeBridgeAddress)
 

--- a/src/events/processSignatureRequests.js
+++ b/src/events/processSignatureRequests.js
@@ -1,12 +1,14 @@
 require('dotenv').config()
 const Web3 = require('web3')
 const logger = require('../services/logger')
+const rpcUrlsManager = require('../services/getRpcUrlsManager')
 const { createMessage } = require('../utils/message')
 
-const { HOME_RPC_URL, VALIDATOR_ADDRESS, VALIDATOR_ADDRESS_PRIVATE_KEY } = process.env
+const { VALIDATOR_ADDRESS, VALIDATOR_ADDRESS_PRIVATE_KEY } = process.env
 
 function processSignatureRequestsBuilder(config) {
-  const homeProvider = new Web3.providers.HttpProvider(HOME_RPC_URL)
+  const homeRpcUrl = rpcUrlsManager.getHomeUrl()
+  const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
   const web3Home = new Web3(homeProvider)
   const homeBridge = new web3Home.eth.Contract(config.homeBridgeAbi, config.homeBridgeAddress)
 

--- a/src/events/processTransfers.js
+++ b/src/events/processTransfers.js
@@ -1,12 +1,12 @@
 require('dotenv').config()
 const Web3 = require('web3')
+const HttpListProvider = require('../utils/HttpListProvider')
 const rpcUrlsManager = require('../services/getRpcUrlsManager')
 
 const { VALIDATOR_ADDRESS } = process.env
 
 function processTransfersBuilder(config) {
-  const homeRpcUrl = rpcUrlsManager.getHomeUrl()
-  const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
+  const homeProvider = new HttpListProvider(rpcUrlsManager.homeUrls)
   const web3Home = new Web3(homeProvider)
   const homeBridge = new web3Home.eth.Contract(config.homeBridgeAbi, config.homeBridgeAddress)
 

--- a/src/events/processTransfers.js
+++ b/src/events/processTransfers.js
@@ -1,10 +1,12 @@
 require('dotenv').config()
 const Web3 = require('web3')
+const rpcUrlsManager = require('../services/getRpcUrlsManager')
 
-const { HOME_RPC_URL, VALIDATOR_ADDRESS } = process.env
+const { VALIDATOR_ADDRESS } = process.env
 
 function processTransfersBuilder(config) {
-  const homeProvider = new Web3.providers.HttpProvider(HOME_RPC_URL)
+  const homeRpcUrl = rpcUrlsManager.getHomeUrl()
+  const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
   const web3Home = new Web3(homeProvider)
   const homeBridge = new web3Home.eth.Contract(config.homeBridgeAbi, config.homeBridgeAddress)
 

--- a/src/sender.js
+++ b/src/sender.js
@@ -5,6 +5,7 @@ const { connectSenderToQueue } = require('./services/amqpClient')
 const { redis, redlock } = require('./services/redisClient')
 const GasPrice = require('./services/gasPrice')
 const logger = require('./services/logger')
+const rpcUrlsManager = require('./services/getRpcUrlsManager')
 const { sendTx } = require('./tx/sendTx')
 const { getNonce, getChainId } = require('./tx/web3')
 const { addExtraGas, checkHTTPS, syncForEach, waitForFunds } = require('./utils/utils')
@@ -29,8 +30,8 @@ async function initialize() {
   try {
     const checkHttps = checkHTTPS(process.env.ALLOW_HTTP)
 
-    checkHttps(process.env.HOME_RPC_URL)
-    checkHttps(process.env.FOREIGN_RPC_URL)
+    rpcUrlsManager.homeUrls.forEach(checkHttps)
+    rpcUrlsManager.foreignUrls.forEach(checkHttps)
 
     GasPrice.start(config.id)
 

--- a/src/sender.js
+++ b/src/sender.js
@@ -91,7 +91,7 @@ async function main({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
 
       try {
         const txHash = await sendTx({
-          rpcUrls: config.urls,
+          chain: config.id,
           data: job.data,
           nonce,
           gasPrice: gasPrice.toString(10),

--- a/src/sender.js
+++ b/src/sender.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 const path = require('path')
 const Web3 = require('web3')
+const HttpListProvider = require('./utils/HttpListProvider')
 const { connectSenderToQueue } = require('./services/amqpClient')
 const { redis, redlock } = require('./services/redisClient')
 const GasPrice = require('./services/gasPrice')
@@ -20,7 +21,7 @@ if (process.argv.length < 3) {
 
 const config = require(path.join('../config/', process.argv[2]))
 
-const provider = new Web3.providers.HttpProvider(config.url)
+const provider = new HttpListProvider(config.urls)
 const web3Instance = new Web3(provider)
 const nonceLock = `lock:${config.id}:nonce`
 const nonceKey = `${config.id}:nonce`
@@ -90,7 +91,7 @@ async function main({ msg, ackMsg, nackMsg, sendToQueue, channel }) {
 
       try {
         const txHash = await sendTx({
-          rpcUrl: config.url,
+          rpcUrls: config.urls,
           data: job.data,
           nonce,
           gasPrice: gasPrice.toString(10),

--- a/src/services/RpcUrlsManager.js
+++ b/src/services/RpcUrlsManager.js
@@ -1,0 +1,21 @@
+function RpcUrlsManager(homeUrls, foreignUrls) {
+  if (!homeUrls) {
+    throw new Error(`Invalid homeUrls: '${homeUrls}'`)
+  }
+  if (!foreignUrls) {
+    throw new Error(`Invalid foreignUrls: '${foreignUrls}'`)
+  }
+
+  this.homeUrls = homeUrls.split(',')
+  this.foreignUrls = foreignUrls.split(',')
+}
+
+RpcUrlsManager.prototype.getHomeUrl = function() {
+  return this.homeUrls[0]
+}
+
+RpcUrlsManager.prototype.getForeignUrl = function() {
+  return this.foreignUrls[0]
+}
+
+module.exports = RpcUrlsManager

--- a/src/services/RpcUrlsManager.js
+++ b/src/services/RpcUrlsManager.js
@@ -1,3 +1,5 @@
+const tryEach = require('../utils/tryEach')
+
 function RpcUrlsManager(homeUrls, foreignUrls) {
   if (!homeUrls) {
     throw new Error(`Invalid homeUrls: '${homeUrls}'`)
@@ -8,6 +10,39 @@ function RpcUrlsManager(homeUrls, foreignUrls) {
 
   this.homeUrls = homeUrls.split(',')
   this.foreignUrls = foreignUrls.split(',')
+}
+
+async function tryEachHelper(originalUrls, f) {
+  // save homeUrls to avoid race condition
+  const urls = JSON.parse(JSON.stringify(originalUrls))
+
+  const [result, index] = await tryEach(urls, f)
+
+  if (index > 0) {
+    // rotate urls
+    const failed = urls.splice(0, index)
+    urls.push(...failed)
+  }
+
+  return [result, urls]
+}
+
+RpcUrlsManager.prototype.tryEach = async function(chain, f) {
+  if (chain !== 'home' && chain !== 'foreign') {
+    throw new Error(`Invalid argument chain: '${chain}'`)
+  }
+
+  const urls = chain === 'home' ? this.homeUrls : this.foreignUrls
+
+  const [result, newUrls] = await tryEachHelper(urls, f)
+
+  if (chain === 'home') {
+    this.homeUrls = newUrls
+  } else {
+    this.foreignUrls = newUrls
+  }
+
+  return result
 }
 
 module.exports = RpcUrlsManager

--- a/src/services/RpcUrlsManager.js
+++ b/src/services/RpcUrlsManager.js
@@ -10,12 +10,4 @@ function RpcUrlsManager(homeUrls, foreignUrls) {
   this.foreignUrls = foreignUrls.split(',')
 }
 
-RpcUrlsManager.prototype.getHomeUrl = function() {
-  return this.homeUrls[0]
-}
-
-RpcUrlsManager.prototype.getForeignUrl = function() {
-  return this.foreignUrls[0]
-}
-
 module.exports = RpcUrlsManager

--- a/src/services/gasPrice.js
+++ b/src/services/gasPrice.js
@@ -7,6 +7,7 @@ const ForeignNativeABI = require('../../abis/ForeignBridgeNativeToErc.abi')
 const HomeErcABI = require('../../abis/HomeBridgeErcToErc.abi')
 const ForeignErcABI = require('../../abis/ForeignBridgeErcToErc.abi')
 const logger = require('../services/logger')
+const rpcUrlsManager = require('../services/getRpcUrlsManager')
 
 const HomeABI = isErcToErc ? HomeErcABI : HomeNativeABI
 const ForeignABI = isErcToErc ? ForeignNativeABI : ForeignErcABI
@@ -17,20 +18,20 @@ const {
   FOREIGN_GAS_PRICE_ORACLE_URL,
   FOREIGN_GAS_PRICE_SPEED_TYPE,
   FOREIGN_GAS_PRICE_UPDATE_INTERVAL,
-  FOREIGN_RPC_URL,
   HOME_BRIDGE_ADDRESS,
   HOME_GAS_PRICE_FALLBACK,
   HOME_GAS_PRICE_ORACLE_URL,
   HOME_GAS_PRICE_SPEED_TYPE,
-  HOME_GAS_PRICE_UPDATE_INTERVAL,
-  HOME_RPC_URL
+  HOME_GAS_PRICE_UPDATE_INTERVAL
 } = process.env
 
-const homeProvider = new Web3.providers.HttpProvider(HOME_RPC_URL)
+const homeRpcUrl = rpcUrlsManager.getHomeUrl()
+const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
 const web3Home = new Web3(homeProvider)
 const homeBridge = new web3Home.eth.Contract(HomeABI, HOME_BRIDGE_ADDRESS)
 
-const foreignProvider = new Web3.providers.HttpProvider(FOREIGN_RPC_URL)
+const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
+const foreignProvider = new Web3.providers.HttpProvider(foreignRpcUrl)
 const web3Foreign = new Web3(foreignProvider)
 const foreignBridge = new web3Foreign.eth.Contract(ForeignABI, FOREIGN_BRIDGE_ADDRESS)
 

--- a/src/services/gasPrice.js
+++ b/src/services/gasPrice.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 const Web3 = require('web3')
 const fetch = require('node-fetch')
+const HttpListProvider = require('../utils/HttpListProvider')
 const { isErcToErc } = require('../../config/base.config')
 const HomeNativeABI = require('../../abis/HomeBridgeNativeToErc.abi')
 const ForeignNativeABI = require('../../abis/ForeignBridgeNativeToErc.abi')
@@ -25,13 +26,11 @@ const {
   HOME_GAS_PRICE_UPDATE_INTERVAL
 } = process.env
 
-const homeRpcUrl = rpcUrlsManager.getHomeUrl()
-const homeProvider = new Web3.providers.HttpProvider(homeRpcUrl)
+const homeProvider = new HttpListProvider(rpcUrlsManager.homeUrls)
 const web3Home = new Web3(homeProvider)
 const homeBridge = new web3Home.eth.Contract(HomeABI, HOME_BRIDGE_ADDRESS)
 
-const foreignRpcUrl = rpcUrlsManager.getForeignUrl()
-const foreignProvider = new Web3.providers.HttpProvider(foreignRpcUrl)
+const foreignProvider = new HttpListProvider(rpcUrlsManager.foreignUrls)
 const web3Foreign = new Web3(foreignProvider)
 const foreignBridge = new web3Foreign.eth.Contract(ForeignABI, FOREIGN_BRIDGE_ADDRESS)
 

--- a/src/services/getRpcUrlsManager.js
+++ b/src/services/getRpcUrlsManager.js
@@ -1,0 +1,3 @@
+const RpcUrlsManager = require('./RpcUrlsManager')
+
+module.exports = new RpcUrlsManager(process.env.HOME_RPC_URL, process.env.FOREIGN_RPC_URL)

--- a/src/tx/sendTx.js
+++ b/src/tx/sendTx.js
@@ -1,9 +1,10 @@
 const Web3Utils = require('web3-utils')
 const fetch = require('node-fetch')
+const tryEach = require('../utils/tryEach')
 
 // eslint-disable-next-line consistent-return
 async function sendTx({
-  rpcUrl,
+  rpcUrls,
   privateKey,
   data,
   nonce,
@@ -28,28 +29,31 @@ async function sendTx({
   )
 
   return sendRawTx({
-    url: rpcUrl,
+    urls: rpcUrls,
     method: 'eth_sendRawTransaction',
     params: [serializedTx.rawTransaction]
   })
 }
 
 // eslint-disable-next-line consistent-return
-async function sendRawTx({ url, params, method }) {
-  // curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":[{see above}],"id":1}'
-  const request = await fetch(url, {
-    headers: {
-      'Content-type': 'application/json'
-    },
-    method: 'POST',
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      method,
-      params,
-      id: Math.floor(Math.random() * 100) + 1
+async function sendRawTx({ urls, params, method }) {
+  const [result] = await tryEach(urls, async url => {
+    // curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":[{see above}],"id":1}'
+    return fetch(url, {
+      headers: {
+        'Content-type': 'application/json'
+      },
+      method: 'POST',
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method,
+        params,
+        id: Math.floor(Math.random() * 100) + 1
+      })
     })
   })
-  const json = await request.json()
+
+  const json = await result.json()
   if (json.error) {
     throw json.error
   }

--- a/src/tx/sendTx.js
+++ b/src/tx/sendTx.js
@@ -1,10 +1,10 @@
 const Web3Utils = require('web3-utils')
 const fetch = require('node-fetch')
-const tryEach = require('../utils/tryEach')
+const rpcUrlsManager = require('../services/getRpcUrlsManager')
 
 // eslint-disable-next-line consistent-return
 async function sendTx({
-  rpcUrls,
+  chain,
   privateKey,
   data,
   nonce,
@@ -29,15 +29,15 @@ async function sendTx({
   )
 
   return sendRawTx({
-    urls: rpcUrls,
+    chain,
     method: 'eth_sendRawTransaction',
     params: [serializedTx.rawTransaction]
   })
 }
 
 // eslint-disable-next-line consistent-return
-async function sendRawTx({ urls, params, method }) {
-  const [result] = await tryEach(urls, async url => {
+async function sendRawTx({ chain, params, method }) {
+  const result = await rpcUrlsManager.tryEach(chain, async url => {
     // curl -X POST --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":[{see above}],"id":1}'
     return fetch(url, {
       headers: {

--- a/src/utils/HttpListProvider.js
+++ b/src/utils/HttpListProvider.js
@@ -1,0 +1,35 @@
+const fetch = require('node-fetch')
+
+function HttpListProvider(urls) {
+  if (!urls || !urls.length) {
+    throw new Error(`Invalid URLs: '${urls}'`)
+  }
+
+  this.urls = urls
+  this.currentIndex = 0
+}
+
+HttpListProvider.prototype.send = async function(payload, callback, retries = 0) {
+  if (retries === this.urls.length) {
+    callback(new Error('Request failed for all urls'))
+  }
+
+  const url = this.urls[this.currentIndex]
+
+  try {
+    const result = await fetch(url, {
+      headers: {
+        'Content-type': 'application/json'
+      },
+      method: 'POST',
+      body: JSON.stringify(payload)
+    }).then(request => request.json())
+
+    callback(null, result)
+  } catch (e) {
+    this.currentIndex = (this.currentIndex + 1) % this.urls.length
+    this.send(payload, callback, retries + 1)
+  }
+}
+
+module.exports = HttpListProvider

--- a/src/utils/HttpListProvider.js
+++ b/src/utils/HttpListProvider.js
@@ -10,11 +10,14 @@ function HttpListProvider(urls) {
 }
 
 HttpListProvider.prototype.send = async function(payload, callback, retries = 0) {
+  // save the currentIndex to avoid race condition
+  const currentIndex = this.currentIndex // eslint-disable-line prefer-destructuring
+
   if (retries === this.urls.length) {
     callback(new Error('Request failed for all urls'))
   }
 
-  const url = this.urls[this.currentIndex]
+  const url = this.urls[currentIndex]
 
   try {
     const result = await fetch(url, {
@@ -27,7 +30,7 @@ HttpListProvider.prototype.send = async function(payload, callback, retries = 0)
 
     callback(null, result)
   } catch (e) {
-    this.currentIndex = (this.currentIndex + 1) % this.urls.length
+    this.currentIndex = (currentIndex + 1) % this.urls.length
     this.send(payload, callback, retries + 1)
   }
 }

--- a/src/utils/tryEach.js
+++ b/src/utils/tryEach.js
@@ -1,0 +1,14 @@
+module.exports = async (array, f) => {
+  const errors = []
+
+  for (let i = 0; i < array.length; i++) {
+    try {
+      const res = await f(array[i])
+      return [res, i]
+    } catch (e) {
+      errors.push(e)
+    }
+  }
+
+  return Promise.reject(errors)
+}

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -103,6 +103,7 @@ async function main({ sendToQueue }) {
   try {
     const lastBlockToProcess = await getLastBlockToProcess()
     if (lastBlockToProcess <= lastProcessedBlock) {
+      logger.info('All blocks already processed')
       return
     }
     const events = await getEvents({

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -1,6 +1,7 @@
 require('dotenv').config()
 const path = require('path')
 const Web3 = require('web3')
+const HttpListProvider = require('./utils/HttpListProvider')
 const { connectWatcherToQueue, connection } = require('./services/amqpClient')
 const { getBlockNumber } = require('./tx/web3')
 const { redis } = require('./services/redisClient')
@@ -21,7 +22,7 @@ const processCollectedSignatures = require('./events/processCollectedSignatures'
 const processAffirmationRequests = require('./events/processAffirmationRequests')(config)
 const processTransfers = require('./events/processTransfers')(config)
 
-const provider = new Web3.providers.HttpProvider(config.url)
+const provider = new HttpListProvider(config.urls)
 const web3Instance = new Web3(provider)
 const bridgeContract = new web3Instance.eth.Contract(config.bridgeAbi, config.bridgeContractAddress)
 const eventContract = new web3Instance.eth.Contract(config.eventAbi, config.eventContractAddress)

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -5,6 +5,7 @@ const { connectWatcherToQueue, connection } = require('./services/amqpClient')
 const { getBlockNumber } = require('./tx/web3')
 const { redis } = require('./services/redisClient')
 const logger = require('./services/logger')
+const rpcUrlsManager = require('./services/getRpcUrlsManager')
 const { getRequiredBlockConfirmations, getEvents } = require('./tx/web3')
 const { checkHTTPS } = require('./utils/utils')
 
@@ -31,8 +32,8 @@ async function initialize() {
   try {
     const checkHttps = checkHTTPS(process.env.ALLOW_HTTP)
 
-    checkHttps(process.env.HOME_RPC_URL)
-    checkHttps(process.env.FOREIGN_RPC_URL)
+    rpcUrlsManager.homeUrls.forEach(checkHttps)
+    rpcUrlsManager.foreignUrls.forEach(checkHttps)
 
     await getLastProcessedBlock()
     connectWatcherToQueue({

--- a/test/tryEach.test.js
+++ b/test/tryEach.test.js
@@ -1,0 +1,65 @@
+const chai = require('chai')
+const chaiAsPromised = require('chai-as-promised')
+const tryEach = require('../src/utils/tryEach')
+
+chai.use(chaiAsPromised)
+const { expect } = chai
+
+describe('tryEach', () => {
+  it('should work with the first element', async () => {
+    // given
+    const array = [1, 2, 3]
+    const f = x => (x === 1 ? Promise.resolve(2 * x) : Promise.reject())
+
+    // when
+    const [result, index] = await tryEach(array, f)
+
+    // then
+    expect(result).to.equal(2)
+    expect(index).to.equal(0)
+  })
+
+  it('should work with the second element', async () => {
+    // given
+    const array = [1, 2, 3]
+    const f = x => (x === 2 ? Promise.resolve(2 * x) : Promise.reject())
+
+    // when
+    const [result, index] = await tryEach(array, f)
+
+    // then
+    expect(result).to.equal(4)
+    expect(index).to.equal(1)
+  })
+
+  it('should work with the last element', async () => {
+    // given
+    const array = [1, 2, 3]
+    const f = x => (x === array[array.length - 1] ? Promise.resolve(2 * x) : Promise.reject())
+
+    // when
+    const [result, index] = await tryEach(array, f)
+
+    // then
+    expect(result).to.equal(6)
+    expect(index).to.equal(2)
+  })
+
+  it('should return array with errors if all elements fail', async () => {
+    // given
+    const array = [1, 2, 3]
+    const f = x => Promise.reject(-x) // eslint-disable-line prefer-promise-reject-errors
+
+    // when
+    return expect(tryEach(array, f)).to.be.rejected.and.eventually.deep.equal([-1, -2, -3])
+  })
+
+  it('should return an empty array if input array is empty', async () => {
+    // given
+    const array = []
+    const f = x => Promise.resolve(x)
+
+    // when
+    return expect(tryEach(array, f)).to.be.rejected.and.eventually.deep.equal([])
+  })
+})


### PR DESCRIPTION
Closes #28.

This PR allows configuring several URLs in the `HOME_RPC_URL` and `FOREIGN_RPC_URL` environment variables.

To do this, two things were necessary: creating a new web3 provider that accepts several URLs (see `HttpListProvider`) and creating a `RpcUrlsManager` service that, given a function, will try it with each available URL until one of them works. This service also centralizes the access to the URLs, instead of having `process.env.HOME_RPC_URL`s all over the code.

---

To test this, I created a simple express app that acts as a proxy and logs each request. Then I started two proxy apps that redirect everything to the port `8545` and two other that redirect to the port `8546`, where I had two parity nodes running. Then I configured the bridge to use two of the proxies as home URLs and the other two as foreign URLs. Finally, I killed and restarted the proxies in several combinations while sending transactions to check that everything was working.

The code for this express proxy is:

```
const proxy = require('express-http-proxy')
const app = require('express')()

const { PORT_FROM, PORT_TO } = process.env

app.use('/', proxy(() => {
  console.log('Request')
  return `http://localhost:${PORT_TO}`
}))

app.listen(PORT_FROM)
```

Then, in four different terminals, I did:

```
PORT_FROM=8555 PORT_TO=8545 node index.js
PORT_FROM=8565 PORT_TO=8545 node index.js
PORT_FROM=8556 PORT_TO=8546 node index.js
PORT_FROM=8566 PORT_TO=8546 node index.js
```

And in the `.env` file I used:

```
HOME_RPC_URL=http://localhost:8555,http://localhost:8565
FOREIGN_RPC_URL=http://localhost:8556,http://localhost:8566
```