### PR TITLE
Upgrade http-list-provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2000,9 +2000,9 @@
       "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs="
     },
     "http-list-provider": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/http-list-provider/-/http-list-provider-0.0.2.tgz",
-      "integrity": "sha512-yUaAO/JJ4fJuUefgYZ/uQwW8o9PAWN6SkQhXOud+C0SJtcuTsTXGuxvVJFM5d/FE4HsyqP6iRdtTS4srxz76ow==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/http-list-provider/-/http-list-provider-0.0.3.tgz",
+      "integrity": "sha512-+l3UPTtL8F5yjRstgZS/XbJ4ez7hirveDyhxoU5zfeiebNpJPgoslF0Owd1rGTQhic2/QuoM9AnWYby8H5NnOw==",
       "requires": {
         "node-fetch": "^2.2.0"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "amqplib": "^0.5.2",
     "bignumber.js": "^7.2.1",
     "dotenv": "^5.0.1",
-    "http-list-provider": "0.0.2",
+    "http-list-provider": "0.0.3",
     "ioredis": "^3.2.2",
     "lodash": "^4.17.10",
     "node-fetch": "^2.1.2",


### PR DESCRIPTION
This allows using the provider without the `new` keyword.