### PR TITLE
Update checkHTTPS warn message

### DIFF
--- a/src/sender.js
+++ b/src/sender.js
@@ -28,8 +28,8 @@ async function initialize() {
   try {
     const checkHttps = checkHTTPS(process.env.ALLOW_HTTP)
 
-    rpcUrlsManager.homeUrls.forEach(checkHttps)
-    rpcUrlsManager.foreignUrls.forEach(checkHttps)
+    rpcUrlsManager.homeUrls.forEach(checkHttps('home'))
+    rpcUrlsManager.foreignUrls.forEach(checkHttps('foreign'))
 
     GasPrice.start(config.id)
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -9,12 +9,16 @@ async function syncForEach(array, callback) {
 }
 
 function checkHTTPS(ALLOW_HTTP) {
-  return function(url) {
-    if (!/^https.*/.test(url)) {
-      if (ALLOW_HTTP !== 'yes') {
-        throw new Error(`http is not allowed: ${url}`)
-      } else {
-        logger.warn(`You are using http (${url}). In production https must be used instead.`)
+  return function(network) {
+    return function(url) {
+      if (!/^https.*/.test(url)) {
+        if (ALLOW_HTTP !== 'yes') {
+          throw new Error(`http is not allowed: ${url}`)
+        } else {
+          logger.warn(
+            `You are using http (${url}) on ${network} network. In production https must be used instead.`
+          )
+        }
       }
     }
   }

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -30,8 +30,8 @@ async function initialize() {
   try {
     const checkHttps = checkHTTPS(process.env.ALLOW_HTTP)
 
-    rpcUrlsManager.homeUrls.forEach(checkHttps)
-    rpcUrlsManager.foreignUrls.forEach(checkHttps)
+    rpcUrlsManager.homeUrls.forEach(checkHttps('home'))
+    rpcUrlsManager.foreignUrls.forEach(checkHttps('foreign'))
 
     await getLastProcessedBlock()
     connectWatcherToQueue({

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -44,22 +44,22 @@ describe('utils', () => {
     })
 
     it('should do nothing if HTTP is allowed and the URL is https', () => {
-      utils.checkHTTPS('yes')('https://www.google.com')
+      utils.checkHTTPS('yes')('home')('https://www.google.com')
       expect(logger.warn.called).to.equal(false)
     })
 
     it('should emit a warning if HTTP is allowed and the URL is http', () => {
-      utils.checkHTTPS('yes')('http://www.google.com')
+      utils.checkHTTPS('yes')('home')('http://www.google.com')
       expect(logger.warn.called).to.equal(true)
     })
 
     it('should do nothing if HTTP is not allowed and the URL is https', () => {
-      utils.checkHTTPS('no')('https://www.google.com')
+      utils.checkHTTPS('no')('home')('https://www.google.com')
       expect(logger.warn.called).to.equal(false)
     })
 
     it('should throw an error if HTTP is not allowed and the URL is http', () => {
-      expect(() => utils.checkHTTPS('no')('http://www.google.com')).to.throw()
+      expect(() => utils.checkHTTPS('no')('home')('http://www.google.com')).to.throw()
     })
   })
 


### PR DESCRIPTION
When checking https use, now warning message specify the network for the url. Example:
```
You are using http (http://localhost:8545) on home network. In production https must be used instead.

You are using http (http://localhost:8555) on foreign network. In production https must be used instead.
```

Closes #84 